### PR TITLE
Updated installation instructions to account for deprecation of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 A modular URL deduplication tool.
 
 ### Installation
+
+> Using Go version 1.17 or higher:
+```
+$ go install github.com/zzeitlin/udedup@latest
+```
+
+> Using Go versions older than 1.17:
 ```
 $ go get github.com/zzeitlin/udedup
 ```


### PR DESCRIPTION
Added install instructions for Go version >= 1.17 to README.md

> Using Go version 1.17 or higher:
```
$ go install github.com/zzeitlin/udedup@latest
```

> Using Go versions older than 1.17:
```
$ go get github.com/zzeitlin/udedup
```
